### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-and-deploy-prod.yml
+++ b/.github/workflows/build-and-deploy-prod.yml
@@ -1,5 +1,8 @@
 name: Build Production and Deploy to Cloudflare Pages
 
+permissions:
+  contents: read
+
 on:
     push:
       tags:
@@ -11,6 +14,9 @@ concurrency:
 
 jobs:
     build_to_cloudflare_pages:
+        permissions:
+          contents: read
+          pages: write
         timeout-minutes: 30
         runs-on: ubuntu-latest
         environment: Production
@@ -67,6 +73,7 @@ jobs:
                 cname_url: p2p.champion.trade
 
     send_slack_notification:
+        permissions: {}
         name: Send Release Slack notification
         environment: Production
         runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/deriv-com/p2p-v0/security/code-scanning/3](https://github.com/deriv-com/p2p-v0/security/code-scanning/3)

To fix the issue, we will add a `permissions` block to the root of the workflow and to individual jobs as needed. This block will explicitly define the minimal permissions required for the workflow and its jobs. For example:
- The `build_to_cloudflare_pages` job will need `contents: read` to check out the repository and possibly `pages: write` to publish to Cloudflare Pages.
- The `send_slack_notification` job will likely not require any permissions, as it uses secrets and external actions.

We will add the `permissions` block at the workflow level to apply default permissions to all jobs and override it for specific jobs if necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
