### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-and-deploy-staging.yml
+++ b/.github/workflows/build-and-deploy-staging.yml
@@ -5,6 +5,9 @@ on:
         branches:
             - 'main'
 
+permissions:
+    contents: read
+
 concurrency:
     group: cloudflare-pages-build-staging
     cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/deriv-com/p2p-v0/security/code-scanning/2](https://github.com/deriv-com/p2p-v0/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the workflow level to explicitly define the minimal permissions required. Based on the workflow's steps, the `contents: read` permission is sufficient for most actions, and no write permissions are required. This block will be added at the root of the workflow file, ensuring it applies to all jobs unless overridden.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
