### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-and-deploy-prod.yml
+++ b/.github/workflows/build-and-deploy-prod.yml
@@ -9,6 +9,10 @@ concurrency:
     group: cloudflare-pages-build-production
     cancel-in-progress: true
 
+permissions:
+    contents: read
+    pages: write
+
 jobs:
     build_to_cloudflare_pages:
         timeout-minutes: 30


### PR DESCRIPTION
Potential fix for [https://github.com/deriv-com/p2p-v0/security/code-scanning/1](https://github.com/deriv-com/p2p-v0/security/code-scanning/1)

To fix the issue, we will add a `permissions` block to the workflow. Since the workflow involves actions like checking out code, installing dependencies, building the project, and publishing to Cloudflare Pages, we will grant the minimal required permissions. Specifically:
- `contents: read` is needed for accessing the repository's contents.
- `pages: write` is required for publishing to Cloudflare Pages.

The `permissions` block will be added at the root level of the workflow to apply to all jobs. This ensures consistency and avoids redundancy.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
