### PR TITLE
fix: handling of ad changes when placing an order

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -375,11 +375,25 @@ export default function BuySellPage() {
       if (data?.options?.channel?.startsWith("adverts/currency/")) {
         if (data?.payload?.data?.event === "update" && data?.payload?.data?.advert) {
           const updatedAdvert = data.payload.data.advert
+          const updatedFields: string[] = data.payload.data.updated_fields || []
 
           setAdverts((currentAdverts) =>
-            currentAdverts.map((ad) =>
-              ad.id == updatedAdvert.id ? { ...ad, effective_rate_display: updatedAdvert.effective_rate_display } : ad,
-            ),
+            currentAdverts.map((ad) => {
+              if (ad.id != updatedAdvert.id) return ad
+              const changes: Partial<typeof ad> = {}
+              if (updatedAdvert.effective_rate_display !== undefined) changes.effective_rate_display = updatedAdvert.effective_rate_display
+              if (updatedFields.includes("version")) changes.version = updatedAdvert.version
+              if (updatedFields.includes("minimum_order_amount")) changes.minimum_order_amount = updatedAdvert.minimum_order_amount
+              if (updatedFields.includes("maximum_order_amount")) changes.maximum_order_amount = updatedAdvert.maximum_order_amount
+              if (updatedFields.includes("actual_maximum_order_amount")) changes.actual_maximum_order_amount = updatedAdvert.actual_maximum_order_amount
+              if (updatedFields.includes("order_expiry_period")) changes.order_expiry_period = updatedAdvert.order_expiry_period
+              if (updatedFields.includes("description")) changes.description = updatedAdvert.description
+              if (updatedFields.includes("payment_method_names")) {
+                changes.payment_method_names = updatedAdvert.payment_method_names
+                changes.payment_methods = updatedAdvert.payment_methods
+              }
+              return { ...ad, ...changes }
+            }),
           )
         }
       }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -241,6 +241,14 @@ export default function BuySellPage() {
     }
   }, [fetchedAdverts])
 
+  // Keep selectedAd in sync with adverts so the sidebar always gets the latest ad data
+  useEffect(() => {
+    if (selectedAd) {
+      const updated = adverts.find((a) => a.id === selectedAd.id)
+      if (updated) setSelectedAd(updated)
+    }
+  }, [adverts])
+
   // Reset scroll position when filters change so sentinel re-enters view and load more works
   useEffect(() => {
     if (scrollContainerRef.current) {

--- a/components/buy-sell/advert-changed-alert.tsx
+++ b/components/buy-sell/advert-changed-alert.tsx
@@ -5,18 +5,18 @@ import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog"
 import { Drawer, DrawerContent, DrawerTitle } from "@/components/ui/drawer"
 import { useIsMobile } from "@/lib/hooks/use-is-mobile"
 
-interface PaymentMethodChangedAlertProps {
+interface AdvertChangedAlertProps {
   isOpen: boolean
   onReview: () => void
 }
 
-export default function PaymentMethodChangedAlert({ isOpen, onReview }: PaymentMethodChangedAlertProps) {
+export default function AdvertChangedAlert({ isOpen, onReview }: AdvertChangedAlertProps) {
   const isMobile = useIsMobile()
 
   const content = (
     <div className="flex flex-col gap-8">
       <p className="text-grayscale-100 text-base">
-        The advertiser updated the payment method. Review the details before placing your order.
+        The ad details changed while you were placing your order. Review the new details to continue.
       </p>
       <Button onClick={onReview} className="w-full">
         Review changes
@@ -30,7 +30,7 @@ export default function PaymentMethodChangedAlert({ isOpen, onReview }: PaymentM
     return (
       <Drawer open={isOpen} onOpenChange={(open) => !open && onReview()}>
         <DrawerContent className="px-6 pb-8">
-          <DrawerTitle className="text-2xl font-bold my-4">Payment method changed</DrawerTitle>
+          <DrawerTitle className="text-2xl font-bold my-4">Ad updated</DrawerTitle>
           {content}
         </DrawerContent>
       </Drawer>
@@ -40,7 +40,7 @@ export default function PaymentMethodChangedAlert({ isOpen, onReview }: PaymentM
   return (
     <Dialog open={isOpen} onOpenChange={(open) => !open && onReview()}>
       <DialogContent className="p-[32px] sm:rounded-[32px]">
-        <DialogTitle className="font-bold text-2xl mb-4">Payment method changed</DialogTitle>
+        <DialogTitle className="font-bold text-2xl mb-4">Ad updated</DialogTitle>
         {content}
       </DialogContent>
     </Dialog>

--- a/components/buy-sell/order-sidebar.tsx
+++ b/components/buy-sell/order-sidebar.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import type React from "react"
-import { useState, useEffect, useMemo } from "react"
+import { useState, useEffect, useMemo, useRef } from "react"
 import { useRouter } from "next/navigation"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
@@ -19,6 +19,7 @@ import { useTranslations } from "@/lib/i18n/use-translations"
 import { useWebSocketContext } from "@/contexts/websocket-context"
 import { useAddPaymentMethod, useUserPaymentMethods } from "@/hooks/use-api-queries"
 import RateChangeConfirmation from "./rate-change-confirmation"
+import PaymentMethodChangedAlert from "./payment-method-changed-alert"
 
 interface OrderSidebarProps {
   isOpen: boolean
@@ -209,51 +210,85 @@ export default function OrderSidebar({ isOpen, onClose, onStartClose, ad, orderT
   const [marketRate, setMarketRate] = useState<number | null>(null)
   const [showRateChangeConfirmation, setShowRateChangeConfirmation] = useState(false)
   const [lockedConfirmationRate, setLockedConfirmationRate] = useState<number | null>(null)
+  const [showPaymentMethodChangedAlert, setShowPaymentMethodChangedAlert] = useState(false)
+  const [adPaymentMethods, setAdPaymentMethods] = useState<string[]>([])
+  const currentPaymentMethodsRef = useRef<string[]>([])
 
   // Use React Query hooks
   const addPaymentMethod = useAddPaymentMethod()
   const { data: paymentMethodsResponse } = useUserPaymentMethods(isOpen)
 
   useEffect(() => {
-    if (
-      isOpen &&
-      ad &&
-      ad.payment_currency &&
-      ad.account_currency &&
-      ad.exchange_rate_type === "float" &&
-      isConnected
-    ) {
-      joinExchangeRatesChannel(ad.account_currency, ad.payment_currency)
+    if (!isOpen || !ad || !ad.payment_currency || !ad.account_currency || !isConnected) return
 
-      const requestTimer = setTimeout(() => {
+    let requestTimer: ReturnType<typeof setTimeout> | null = null
+
+    if (ad.exchange_rate_type === "float") {
+      joinExchangeRatesChannel(ad.account_currency, ad.payment_currency)
+      requestTimer = setTimeout(() => {
         requestExchangeRate(ad.account_currency, ad.payment_currency)
       }, 400)
+    }
 
-      const unsubscribe = subscribe((data) => {
-        const expectedChannel = `exchange_rates/${ad.account_currency}/${ad.payment_currency}`
+    const unsubscribe = subscribe((data) => {
+      const expectedChannel = `exchange_rates/${ad.account_currency}/${ad.payment_currency}`
 
+      if (ad.exchange_rate_type === "float") {
         if (data.options.channel === expectedChannel && data.payload?.rate) {
           setMarketRate(data.payload.rate * ((ad.exchange_rate / 100) + 1))
         } else if (data.options.channel === expectedChannel && data.payload?.data?.rate) {
           setMarketRate(data.payload.data.rate * ((ad.exchange_rate / 100) + 1))
           ad.effective_rate_display = Number(data.payload.data.rate * ((ad.exchange_rate / 100) + 1)).toFixed(6)
-        } else if (data?.options?.channel?.startsWith("adverts/currency/")) {
-          if (data?.payload?.data?.event === "update" && data?.payload?.data?.advert) {
-            const updatedAdvert = data.payload.data.advert
-            if (ad.id == updatedAdvert.id) {
+        }
+      }
+
+      if (data?.options?.channel?.startsWith("adverts/currency/")) {
+        if (data?.payload?.data?.event === "update" && data?.payload?.data?.advert) {
+          const updatedAdvert = data.payload.data.advert
+          if (ad.id == updatedAdvert.id) {
+            if (ad.exchange_rate_type === "float") {
               setMarketRate(updatedAdvert.effective_rate)
               ad.effective_rate_display = updatedAdvert.effective_rate_display
             }
+
+            const newMethods: string[] = updatedAdvert.payment_methods || []
+            const currentMethods = currentPaymentMethodsRef.current
+            const hasChanged =
+              newMethods.length !== currentMethods.length ||
+              newMethods.some((m) => !currentMethods.includes(m))
+            if (hasChanged) {
+              setAdPaymentMethods(newMethods)
+              setShowPaymentMethodChangedAlert(true)
+            }
           }
         }
-      })
-      return () => {
-        clearTimeout(requestTimer)
-        leaveExchangeRatesChannel(ad.account_currency, ad.payment_currency)
-        unsubscribe()
       }
+    })
+
+    return () => {
+      if (requestTimer) clearTimeout(requestTimer)
+      if (ad.exchange_rate_type === "float") {
+        leaveExchangeRatesChannel(ad.account_currency, ad.payment_currency)
+      }
+      unsubscribe()
     }
   }, [isOpen, ad, isConnected])
+
+  useEffect(() => {
+    if (ad && isOpen) {
+      const methods = ad.payment_methods || []
+      setAdPaymentMethods(methods)
+      currentPaymentMethodsRef.current = methods
+    }
+    if (!isOpen) {
+      setShowPaymentMethodChangedAlert(false)
+    }
+  }, [ad?.id, isOpen])
+
+  useEffect(() => {
+    currentPaymentMethodsRef.current = adPaymentMethods
+  }, [adPaymentMethods])
+
 
   useEffect(() => {
     if (isOpen) {
@@ -444,6 +479,7 @@ export default function OrderSidebar({ isOpen, onClose, onStartClose, ad, orderT
       setTempSelectedPaymentMethods([])
       setShowRateChangeConfirmation(false)
       setLockedConfirmationRate(null)
+      setShowPaymentMethodChangedAlert(false)
       onClose()
     }, 300)
   }
@@ -493,15 +529,14 @@ export default function OrderSidebar({ isOpen, onClose, onStartClose, ad, orderT
 
   // Filter and transform user payment methods based on ad's accepted methods
   const filteredPaymentMethods = useMemo(() => {
-    if (!paymentMethodsResponse?.data || !ad?.payment_methods) return []
+    if (!paymentMethodsResponse?.data || !adPaymentMethods.length) return []
 
-    const buyerAcceptedMethods = ad.payment_methods || []
     return paymentMethodsResponse.data.filter((method: any) => {
-      return buyerAcceptedMethods.some(
+      return adPaymentMethods.some(
         (buyerMethod: string) => method.method.toLowerCase() === buyerMethod.toLowerCase(),
       )
     })
-  }, [paymentMethodsResponse?.data, ad?.payment_methods])
+  }, [paymentMethodsResponse?.data, adPaymentMethods])
 
   // Set user payment methods and seller payment methods
   useEffect(() => {
@@ -509,13 +544,12 @@ export default function OrderSidebar({ isOpen, onClose, onStartClose, ad, orderT
       setUserPaymentMethods(filteredPaymentMethods)
     }
 
-    const buyerAcceptedMethods = ad?.payment_methods || []
-    const sellerMethods: SellerPaymentMethod[] = buyerAcceptedMethods.map((method: string) => ({
+    const sellerMethods: SellerPaymentMethod[] = adPaymentMethods.map((method: string) => ({
       type: method.toLowerCase().includes("bank") ? "bank" : "ewallet",
       method: method,
     }))
     setSellerPaymentMethods(sellerMethods)
-  }, [filteredPaymentMethods, ad?.payment_methods])
+  }, [filteredPaymentMethods, adPaymentMethods])
 
   if (!isOpen && !isAnimating) return null
 
@@ -637,7 +671,7 @@ export default function OrderSidebar({ isOpen, onClose, onStartClose, ad, orderT
                     {isBuy ? t("order.buyersPaymentMethods") : t("order.sellersPaymentMethods")}
                   </h3>
                   <div className="flex flex-wrap gap-4">
-                    {ad.payment_methods?.map((method, index) => (
+                    {adPaymentMethods.map((method, index) => (
                       <div key={index} className="flex items-center">
                         <div
                           className={`h-2 w-2 rounded-full mr-2 ${method.toLowerCase().includes("bank") ? "bg-paymentMethod-bank" : "bg-paymentMethod-ewallet"
@@ -687,12 +721,19 @@ export default function OrderSidebar({ isOpen, onClose, onStartClose, ad, orderT
         <AddPaymentMethodPanel
           onAdd={handleAddPaymentMethod}
           isLoading={addPaymentMethod.isPending}
-          allowedPaymentMethods={ad?.payment_methods}
+          allowedPaymentMethods={adPaymentMethods}
           onClose={() => {
             setShowAddPaymentPanel(false)
             setSelectedPaymentMethodType(undefined)
           }}
           selectedMethod={selectedPaymentMethodType}
+        />
+      )}
+
+      {ad && (
+        <PaymentMethodChangedAlert
+          isOpen={showPaymentMethodChangedAlert}
+          onReview={() => setShowPaymentMethodChangedAlert(false)}
         />
       )}
 

--- a/components/buy-sell/order-sidebar.tsx
+++ b/components/buy-sell/order-sidebar.tsx
@@ -237,7 +237,7 @@ export default function OrderSidebar({ isOpen, onClose, onStartClose, ad, orderT
       joinExchangeRatesChannel(ad.account_currency, ad.payment_currency)
       requestTimer = setTimeout(() => {
         requestExchangeRate(ad.account_currency, ad.payment_currency)
-      }, 50)
+      }, 400)
     }
 
     const unsubscribe = subscribe((data) => {

--- a/components/buy-sell/order-sidebar.tsx
+++ b/components/buy-sell/order-sidebar.tsx
@@ -19,7 +19,7 @@ import { useTranslations } from "@/lib/i18n/use-translations"
 import { useWebSocketContext } from "@/contexts/websocket-context"
 import { useAddPaymentMethod, useUserPaymentMethods } from "@/hooks/use-api-queries"
 import RateChangeConfirmation from "./rate-change-confirmation"
-import PaymentMethodChangedAlert from "./payment-method-changed-alert"
+import AdvertChangedAlert from "./advert-changed-alert"
 
 interface OrderSidebarProps {
   isOpen: boolean
@@ -210,7 +210,8 @@ export default function OrderSidebar({ isOpen, onClose, onStartClose, ad, orderT
   const [marketRate, setMarketRate] = useState<number | null>(null)
   const [showRateChangeConfirmation, setShowRateChangeConfirmation] = useState(false)
   const [lockedConfirmationRate, setLockedConfirmationRate] = useState<number | null>(null)
-  const [showPaymentMethodChangedAlert, setShowPaymentMethodChangedAlert] = useState(false)
+  const [advertChanged, setAdvertChanged] = useState(false)
+  const [showAdvertChangedAlert, setShowAdvertChangedAlert] = useState(false)
   const [adPaymentMethods, setAdPaymentMethods] = useState<string[]>([])
   const currentPaymentMethodsRef = useRef<string[]>([])
 
@@ -267,7 +268,10 @@ export default function OrderSidebar({ isOpen, onClose, onStartClose, ad, orderT
               setAdPaymentMethods(newMethods)
               setSelectedPaymentMethods([])
               setTempSelectedPaymentMethods([])
-              setShowPaymentMethodChangedAlert(true)
+            }
+
+            if (updatedFields.length > 0) {
+              setAdvertChanged(true)
             }
           }
         }
@@ -290,7 +294,8 @@ export default function OrderSidebar({ isOpen, onClose, onStartClose, ad, orderT
       currentPaymentMethodsRef.current = methods
     }
     if (!isOpen) {
-      setShowPaymentMethodChangedAlert(false)
+      setShowAdvertChangedAlert(false)
+      setAdvertChanged(false)
     }
   }, [ad?.id, isOpen])
 
@@ -356,6 +361,11 @@ export default function OrderSidebar({ isOpen, onClose, onStartClose, ad, orderT
 
   const handleSubmit = async () => {
     if (!ad) return
+
+    if (advertChanged) {
+      setShowAdvertChangedAlert(true)
+      return
+    }
 
     if (ad.exchange_rate_type == "float" && marketRate && marketRate != ad.effective_rate) {
       setLockedConfirmationRate(marketRate)
@@ -492,7 +502,8 @@ export default function OrderSidebar({ isOpen, onClose, onStartClose, ad, orderT
       setTempSelectedPaymentMethods([])
       setShowRateChangeConfirmation(false)
       setLockedConfirmationRate(null)
-      setShowPaymentMethodChangedAlert(false)
+      setShowAdvertChangedAlert(false)
+      setAdvertChanged(false)
       onClose()
     }, 300)
   }
@@ -744,9 +755,9 @@ export default function OrderSidebar({ isOpen, onClose, onStartClose, ad, orderT
       )}
 
       {ad && (
-        <PaymentMethodChangedAlert
-          isOpen={showPaymentMethodChangedAlert}
-          onReview={() => setShowPaymentMethodChangedAlert(false)}
+        <AdvertChangedAlert
+          isOpen={showAdvertChangedAlert}
+          onReview={() => { setShowAdvertChangedAlert(false); setAdvertChanged(false) }}
         />
       )}
 

--- a/components/buy-sell/order-sidebar.tsx
+++ b/components/buy-sell/order-sidebar.tsx
@@ -214,7 +214,6 @@ export default function OrderSidebar({ isOpen, onClose, onStartClose, ad, orderT
   const [showAdvertChangedAlert, setShowAdvertChangedAlert] = useState(false)
   const [adPaymentMethods, setAdPaymentMethods] = useState<string[]>([])
   const currentPaymentMethodsRef = useRef<string[]>([])
-  const prevAdIdRef = useRef<number | undefined>(undefined)
   const [adVersion, setAdVersion] = useState<number | undefined>(ad?.version)
   const [adMinOrderAmount, setAdMinOrderAmount] = useState(ad?.minimum_order_amount ?? "0.00")
   const [adMaxOrderAmount, setAdMaxOrderAmount] = useState(ad?.maximum_order_amount ?? "0.00")
@@ -238,7 +237,7 @@ export default function OrderSidebar({ isOpen, onClose, onStartClose, ad, orderT
       joinExchangeRatesChannel(ad.account_currency, ad.payment_currency)
       requestTimer = setTimeout(() => {
         requestExchangeRate(ad.account_currency, ad.payment_currency)
-      }, 400)
+      }, 50)
     }
 
     const unsubscribe = subscribe((data) => {
@@ -311,9 +310,6 @@ export default function OrderSidebar({ isOpen, onClose, onStartClose, ad, orderT
 
   useEffect(() => {
     if (ad && isOpen) {
-      const isNewAd = prevAdIdRef.current !== ad.id
-      prevAdIdRef.current = ad.id
-
       const methods = ad.payment_methods || []
       setAdPaymentMethods(methods)
       currentPaymentMethodsRef.current = methods
@@ -323,12 +319,7 @@ export default function OrderSidebar({ isOpen, onClose, onStartClose, ad, orderT
       setAdActualMaxOrderAmount(ad.actual_maximum_order_amount ?? "0.00")
       setAdOrderExpiryPeriod(ad.order_expiry_period ?? 0)
       setAdDescription(ad.description ?? "")
-      // For float ads on reopen of the same ad, keep last known rate — the WS will
-      // provide the fresh rate. Resetting from the prop would show a stale value
-      // because page.tsx doesn't subscribe to the exchange_rates channel.
-      if (isNewAd || ad.exchange_rate_type !== "float") {
-        setAdEffectiveRateDisplay(ad.effective_rate_display)
-      }
+      setAdEffectiveRateDisplay(ad.effective_rate_display)
     }
     if (!isOpen) {
       setShowAdvertChangedAlert(false)

--- a/components/buy-sell/order-sidebar.tsx
+++ b/components/buy-sell/order-sidebar.tsx
@@ -214,6 +214,13 @@ export default function OrderSidebar({ isOpen, onClose, onStartClose, ad, orderT
   const [showAdvertChangedAlert, setShowAdvertChangedAlert] = useState(false)
   const [adPaymentMethods, setAdPaymentMethods] = useState<string[]>([])
   const currentPaymentMethodsRef = useRef<string[]>([])
+  const [adVersion, setAdVersion] = useState<number | undefined>(ad?.version)
+  const [adMinOrderAmount, setAdMinOrderAmount] = useState(ad?.minimum_order_amount ?? "0.00")
+  const [adMaxOrderAmount, setAdMaxOrderAmount] = useState(ad?.maximum_order_amount ?? "0.00")
+  const [adActualMaxOrderAmount, setAdActualMaxOrderAmount] = useState(ad?.actual_maximum_order_amount ?? "0.00")
+  const [adOrderExpiryPeriod, setAdOrderExpiryPeriod] = useState(ad?.order_expiry_period ?? 0)
+  const [adDescription, setAdDescription] = useState(ad?.description ?? "")
+  const [adEffectiveRateDisplay, setAdEffectiveRateDisplay] = useState<number | string | undefined>(ad?.effective_rate_display)
 
   // Use React Query hooks
   const addPaymentMethod = useAddPaymentMethod()
@@ -238,8 +245,9 @@ export default function OrderSidebar({ isOpen, onClose, onStartClose, ad, orderT
         if (data.options.channel === expectedChannel && data.payload?.rate) {
           setMarketRate(data.payload.rate * ((ad.exchange_rate / 100) + 1))
         } else if (data.options.channel === expectedChannel && data.payload?.data?.rate) {
-          setMarketRate(data.payload.data.rate * ((ad.exchange_rate / 100) + 1))
-          ad.effective_rate_display = Number(data.payload.data.rate * ((ad.exchange_rate / 100) + 1)).toFixed(6)
+          const newRate = data.payload.data.rate * ((ad.exchange_rate / 100) + 1)
+          setMarketRate(newRate)
+          setAdEffectiveRateDisplay(Number(newRate).toFixed(6))
         }
       }
 
@@ -249,16 +257,16 @@ export default function OrderSidebar({ isOpen, onClose, onStartClose, ad, orderT
           if (ad.id == updatedAdvert.id) {
             const updatedFields: string[] = data.payload.data.updated_fields || []
 
-            if (updatedFields.includes("version")) ad.version = updatedAdvert.version
-            if (updatedFields.includes("minimum_order_amount")) ad.minimum_order_amount = updatedAdvert.minimum_order_amount
-            if (updatedFields.includes("maximum_order_amount")) ad.maximum_order_amount = updatedAdvert.maximum_order_amount
-            if (updatedFields.includes("actual_maximum_order_amount")) ad.actual_maximum_order_amount = updatedAdvert.actual_maximum_order_amount
-            if (updatedFields.includes("order_expiry_period")) ad.order_expiry_period = updatedAdvert.order_expiry_period
-            if (updatedFields.includes("description")) ad.description = updatedAdvert.description
+            if (updatedFields.includes("version")) setAdVersion(updatedAdvert.version)
+            if (updatedFields.includes("minimum_order_amount")) setAdMinOrderAmount(updatedAdvert.minimum_order_amount)
+            if (updatedFields.includes("maximum_order_amount")) setAdMaxOrderAmount(updatedAdvert.maximum_order_amount)
+            if (updatedFields.includes("actual_maximum_order_amount")) setAdActualMaxOrderAmount(updatedAdvert.actual_maximum_order_amount)
+            if (updatedFields.includes("order_expiry_period")) setAdOrderExpiryPeriod(updatedAdvert.order_expiry_period)
+            if (updatedFields.includes("description")) setAdDescription(updatedAdvert.description)
 
             if (ad.exchange_rate_type === "float") {
               setMarketRate(updatedAdvert.effective_rate)
-              ad.effective_rate_display = updatedAdvert.effective_rate_display
+              setAdEffectiveRateDisplay(updatedAdvert.effective_rate_display)
             }
 
             if (updatedFields.includes("payment_method_names")) {
@@ -294,6 +302,13 @@ export default function OrderSidebar({ isOpen, onClose, onStartClose, ad, orderT
       const methods = ad.payment_methods || []
       setAdPaymentMethods(methods)
       currentPaymentMethodsRef.current = methods
+      setAdVersion(ad.version)
+      setAdMinOrderAmount(ad.minimum_order_amount ?? "0.00")
+      setAdMaxOrderAmount(ad.maximum_order_amount ?? "0.00")
+      setAdActualMaxOrderAmount(ad.actual_maximum_order_amount ?? "0.00")
+      setAdOrderExpiryPeriod(ad.order_expiry_period ?? 0)
+      setAdDescription(ad.description ?? "")
+      setAdEffectiveRateDisplay(ad.effective_rate_display)
     }
     if (!isOpen) {
       setShowAdvertChangedAlert(false)
@@ -315,24 +330,21 @@ export default function OrderSidebar({ isOpen, onClose, onStartClose, ad, orderT
   useEffect(() => {
     if (ad && amount) {
       const numAmount = Number.parseFloat(amount)
-      const exchangeRate = ad.effective_rate_display || 0
+      const exchangeRate = Number(adEffectiveRateDisplay) || 0
       const total = numAmount * exchangeRate
       setTotalAmount(total)
 
-      const minLimit = ad.minimum_order_amount || "0.00"
-      const maxLimit = ad.actual_maximum_order_amount || "0.00"
-
       if (orderType === "buy" && numAmount > p2pBalance) {
         setValidationError(t("order.insufficientBalance"))
-      } else if (numAmount < minLimit || numAmount > maxLimit) {
-        setValidationError(t("order.orderLimitError", { min: minLimit, max: maxLimit, currency: ad.account_currency }))
+      } else if (numAmount < Number(adMinOrderAmount) || numAmount > Number(adActualMaxOrderAmount)) {
+        setValidationError(t("order.orderLimitError", { min: adMinOrderAmount, max: adActualMaxOrderAmount, currency: ad.account_currency }))
       } else {
         setValidationError(null)
       }
     }
 
     if (!amount) setTotalAmount(0)
-  }, [amount, ad, orderType, p2pBalance, t, marketRate])
+  }, [amount, ad?.account_currency, adEffectiveRateDisplay, adMinOrderAmount, adActualMaxOrderAmount, orderType, p2pBalance, t, marketRate])
 
   const handleShowPaymentSelection = () => {
     showAlert({
@@ -389,7 +401,7 @@ export default function OrderSidebar({ isOpen, onClose, onStartClose, ad, orderT
       const numAmount = Number.parseFloat(amount)
 
       const rateToUse = lockedConfirmationRate || marketRate
-      const order = await createOrder(ad.id, rateToUse, numAmount, selectedPaymentMethods, ad.version)
+      const order = await createOrder(ad.id, rateToUse, numAmount, selectedPaymentMethods, adVersion)
       if (order.errors.length > 0) {
         const errorCode = order.errors[0].code
         if (errorCode === "OrderExists") {
@@ -550,8 +562,8 @@ export default function OrderSidebar({ isOpen, onClose, onStartClose, ad, orderT
   const title = isBuy ? `${t("common.sell")} USD` : `${t("common.buy")} USD`
   const youSendText = isBuy ? t("order.youReceive") : t("order.youPay")
 
-  const minLimit = ad?.minimum_order_amount || "0.00"
-  const maxLimit = ad?.actual_maximum_order_amount || "0.00"
+  const minLimit = adMinOrderAmount
+  const maxLimit = adActualMaxOrderAmount
 
   // Filter and transform user payment methods based on ad's accepted methods
   const filteredPaymentMethods = useMemo(() => {
@@ -670,7 +682,7 @@ export default function OrderSidebar({ isOpen, onClose, onStartClose, ad, orderT
                   <div className="flex justify-between items-center mb-2">
                     <span className="text-grayscale-text-muted">{t("order.exchangeRate")}</span>
                     <span className="text-slate-1200">
-                      {ad.effective_rate_display} {ad.payment_currency}
+                      {adEffectiveRateDisplay} {ad.payment_currency}
                       <span className="text-grayscale-text-muted"> /{ad.account_currency}</span>
                     </span>
                   </div>
@@ -683,7 +695,7 @@ export default function OrderSidebar({ isOpen, onClose, onStartClose, ad, orderT
                   <div className="flex justify-between items-center mb-2">
                     <span className="text-grayscale-text-muted">{t("order.paymentTime")}</span>
                     <span className="text-slate-1200">
-                      {ad.order_expiry_period} {t("market.min")}
+                      {adOrderExpiryPeriod} {t("market.min")}
                     </span>
                   </div>
                   <div className="flex justify-between items-center mb-2">
@@ -714,7 +726,7 @@ export default function OrderSidebar({ isOpen, onClose, onStartClose, ad, orderT
                     {isBuy ? t("order.buyersInstructions") : t("order.sellersInstructions")}
                   </h3>
                   <p className="text-slate-1200 break-words mt-2">
-                    {ad.description || "-"}
+                    {adDescription || "-"}
                   </p>
                 </div>
 

--- a/components/buy-sell/order-sidebar.tsx
+++ b/components/buy-sell/order-sidebar.tsx
@@ -249,12 +249,14 @@ export default function OrderSidebar({ isOpen, onClose, onStartClose, ad, orderT
       if (currentAd.exchange_rate_type === "float") {
         if (data.options.channel === expectedChannel && data.payload?.rate) {
           const newRate = data.payload.rate * ((currentAd.exchange_rate / 100) + 1)
-          setMarketRate(newRate)
-          setAdEffectiveRateDisplay(Number(newRate).toFixed(6))
+          const display = Number(newRate).toFixed(6)
+          setAdEffectiveRateDisplay(display)
+          setMarketRate(Number(display))
         } else if (data.options.channel === expectedChannel && data.payload?.data?.rate) {
           const newRate = data.payload.data.rate * ((currentAd.exchange_rate / 100) + 1)
-          setMarketRate(newRate)
-          setAdEffectiveRateDisplay(Number(newRate).toFixed(6))
+          const display = Number(newRate).toFixed(6)
+          setAdEffectiveRateDisplay(display)
+          setMarketRate(Number(display))
         }
       }
 
@@ -272,10 +274,11 @@ export default function OrderSidebar({ isOpen, onClose, onStartClose, ad, orderT
             if (updatedFields.includes("description")) setAdDescription(updatedAdvert.description)
 
             if (updatedAdvert.effective_rate_display !== undefined) {
-              setAdEffectiveRateDisplay(updatedAdvert.effective_rate_display)
-            }
-            if (currentAd.exchange_rate_type === "float" && updatedAdvert.effective_rate !== undefined) {
-              setMarketRate(updatedAdvert.effective_rate)
+              const display = Number(updatedAdvert.effective_rate_display).toFixed(6)
+              setAdEffectiveRateDisplay(display)
+              if (currentAd.exchange_rate_type === "float") {
+                setMarketRate(Number(display))
+              }
             }
 
             if (updatedFields.includes("payment_method_names")) {
@@ -331,6 +334,8 @@ export default function OrderSidebar({ isOpen, onClose, onStartClose, ad, orderT
       setShowAdvertChangedAlert(false)
       setAdvertChanged(false)
       setMarketRate(null)
+      setShowRateChangeConfirmation(false)
+      setLockedConfirmationRate(null)
     }
   }, [ad?.id, isOpen])
 
@@ -397,7 +402,7 @@ export default function OrderSidebar({ isOpen, onClose, onStartClose, ad, orderT
   const handleSubmit = async () => {
     if (!ad) return
 
-    if (ad.exchange_rate_type == "float" && marketRate && marketRate != Number(adEffectiveRateDisplay)) {
+    if (ad.exchange_rate_type == "float" && marketRate && Number(marketRate.toFixed(6)) !== Number(Number(adEffectiveRateDisplay).toFixed(6))) {
       setLockedConfirmationRate(marketRate)
       setShowRateChangeConfirmation(true)
       return

--- a/components/buy-sell/order-sidebar.tsx
+++ b/components/buy-sell/order-sidebar.tsx
@@ -243,7 +243,9 @@ export default function OrderSidebar({ isOpen, onClose, onStartClose, ad, orderT
 
       if (ad.exchange_rate_type === "float") {
         if (data.options.channel === expectedChannel && data.payload?.rate) {
-          setMarketRate(data.payload.rate * ((ad.exchange_rate / 100) + 1))
+          const newRate = data.payload.rate * ((ad.exchange_rate / 100) + 1)
+          setMarketRate(newRate)
+          setAdEffectiveRateDisplay(Number(newRate).toFixed(6))
         } else if (data.options.channel === expectedChannel && data.payload?.data?.rate) {
           const newRate = data.payload.data.rate * ((ad.exchange_rate / 100) + 1)
           setMarketRate(newRate)
@@ -330,7 +332,10 @@ export default function OrderSidebar({ isOpen, onClose, onStartClose, ad, orderT
   useEffect(() => {
     if (ad && amount) {
       const numAmount = Number.parseFloat(amount)
-      const exchangeRate = Number(adEffectiveRateDisplay) || 0
+      const exchangeRate =
+        ad.exchange_rate_type === "float" && marketRate
+          ? marketRate
+          : Number(adEffectiveRateDisplay) || 0
       const total = numAmount * exchangeRate
       setTotalAmount(total)
 

--- a/components/buy-sell/order-sidebar.tsx
+++ b/components/buy-sell/order-sidebar.tsx
@@ -270,7 +270,9 @@ export default function OrderSidebar({ isOpen, onClose, onStartClose, ad, orderT
               setTempSelectedPaymentMethods([])
             }
 
-            if (updatedFields.length > 0) {
+            const rateFields = new Set(["exchange_rate", "effective_rate", "effective_rate_display"])
+            const hasNonRateUpdates = updatedFields.some((f) => !rateFields.has(f))
+            if (hasNonRateUpdates) {
               setAdvertChanged(true)
             }
           }

--- a/components/buy-sell/order-sidebar.tsx
+++ b/components/buy-sell/order-sidebar.tsx
@@ -315,6 +315,7 @@ export default function OrderSidebar({ isOpen, onClose, onStartClose, ad, orderT
     if (!isOpen) {
       setShowAdvertChangedAlert(false)
       setAdvertChanged(false)
+      setMarketRate(null)
     }
   }, [ad?.id, isOpen])
 
@@ -523,6 +524,7 @@ export default function OrderSidebar({ isOpen, onClose, onStartClose, ad, orderT
       setLockedConfirmationRate(null)
       setShowAdvertChangedAlert(false)
       setAdvertChanged(false)
+      setMarketRate(null)
       onClose()
     }, 300)
   }

--- a/components/buy-sell/order-sidebar.tsx
+++ b/components/buy-sell/order-sidebar.tsx
@@ -214,6 +214,7 @@ export default function OrderSidebar({ isOpen, onClose, onStartClose, ad, orderT
   const [showAdvertChangedAlert, setShowAdvertChangedAlert] = useState(false)
   const [adPaymentMethods, setAdPaymentMethods] = useState<string[]>([])
   const currentPaymentMethodsRef = useRef<string[]>([])
+  const prevAdIdRef = useRef<number | undefined>(undefined)
   const [adVersion, setAdVersion] = useState<number | undefined>(ad?.version)
   const [adMinOrderAmount, setAdMinOrderAmount] = useState(ad?.minimum_order_amount ?? "0.00")
   const [adMaxOrderAmount, setAdMaxOrderAmount] = useState(ad?.maximum_order_amount ?? "0.00")
@@ -221,6 +222,8 @@ export default function OrderSidebar({ isOpen, onClose, onStartClose, ad, orderT
   const [adOrderExpiryPeriod, setAdOrderExpiryPeriod] = useState(ad?.order_expiry_period ?? 0)
   const [adDescription, setAdDescription] = useState(ad?.description ?? "")
   const [adEffectiveRateDisplay, setAdEffectiveRateDisplay] = useState<number | string | undefined>(ad?.effective_rate_display)
+  const adRef = useRef(ad)
+  useEffect(() => { adRef.current = ad }, [ad])
 
   // Use React Query hooks
   const addPaymentMethod = useAddPaymentMethod()
@@ -239,15 +242,17 @@ export default function OrderSidebar({ isOpen, onClose, onStartClose, ad, orderT
     }
 
     const unsubscribe = subscribe((data) => {
-      const expectedChannel = `exchange_rates/${ad.account_currency}/${ad.payment_currency}`
+      const currentAd = adRef.current
+      if (!currentAd) return
+      const expectedChannel = `exchange_rates/${currentAd.account_currency}/${currentAd.payment_currency}`
 
-      if (ad.exchange_rate_type === "float") {
+      if (currentAd.exchange_rate_type === "float") {
         if (data.options.channel === expectedChannel && data.payload?.rate) {
-          const newRate = data.payload.rate * ((ad.exchange_rate / 100) + 1)
+          const newRate = data.payload.rate * ((currentAd.exchange_rate / 100) + 1)
           setMarketRate(newRate)
           setAdEffectiveRateDisplay(Number(newRate).toFixed(6))
         } else if (data.options.channel === expectedChannel && data.payload?.data?.rate) {
-          const newRate = data.payload.data.rate * ((ad.exchange_rate / 100) + 1)
+          const newRate = data.payload.data.rate * ((currentAd.exchange_rate / 100) + 1)
           setMarketRate(newRate)
           setAdEffectiveRateDisplay(Number(newRate).toFixed(6))
         }
@@ -256,7 +261,7 @@ export default function OrderSidebar({ isOpen, onClose, onStartClose, ad, orderT
       if (data?.options?.channel?.startsWith("adverts/currency/")) {
         if (data?.payload?.data?.event === "update" && data?.payload?.data?.advert) {
           const updatedAdvert = data.payload.data.advert
-          if (ad.id == updatedAdvert.id) {
+          if (currentAd.id == updatedAdvert.id) {
             const updatedFields: string[] = data.payload.data.updated_fields || []
 
             if (updatedFields.includes("version")) setAdVersion(updatedAdvert.version)
@@ -266,14 +271,16 @@ export default function OrderSidebar({ isOpen, onClose, onStartClose, ad, orderT
             if (updatedFields.includes("order_expiry_period")) setAdOrderExpiryPeriod(updatedAdvert.order_expiry_period)
             if (updatedFields.includes("description")) setAdDescription(updatedAdvert.description)
 
-            if (ad.exchange_rate_type === "float") {
-              setMarketRate(updatedAdvert.effective_rate)
+            if (updatedAdvert.effective_rate_display !== undefined) {
               setAdEffectiveRateDisplay(updatedAdvert.effective_rate_display)
+            }
+            if (currentAd.exchange_rate_type === "float" && updatedAdvert.effective_rate !== undefined) {
+              setMarketRate(updatedAdvert.effective_rate)
             }
 
             if (updatedFields.includes("payment_method_names")) {
               const newMethods: string[] = updatedAdvert.payment_methods || []
-              ad.payment_method_names = updatedAdvert.payment_method_names || ad.payment_method_names
+              currentAd.payment_method_names = updatedAdvert.payment_method_names || currentAd.payment_method_names
               currentPaymentMethodsRef.current = newMethods
               setAdPaymentMethods(newMethods)
               setSelectedPaymentMethods([])
@@ -297,10 +304,13 @@ export default function OrderSidebar({ isOpen, onClose, onStartClose, ad, orderT
       }
       unsubscribe()
     }
-  }, [isOpen, ad, isConnected])
+  }, [isOpen, ad?.id, ad?.account_currency, ad?.payment_currency, ad?.exchange_rate_type, isConnected])
 
   useEffect(() => {
     if (ad && isOpen) {
+      const isNewAd = prevAdIdRef.current !== ad.id
+      prevAdIdRef.current = ad.id
+
       const methods = ad.payment_methods || []
       setAdPaymentMethods(methods)
       currentPaymentMethodsRef.current = methods
@@ -310,7 +320,12 @@ export default function OrderSidebar({ isOpen, onClose, onStartClose, ad, orderT
       setAdActualMaxOrderAmount(ad.actual_maximum_order_amount ?? "0.00")
       setAdOrderExpiryPeriod(ad.order_expiry_period ?? 0)
       setAdDescription(ad.description ?? "")
-      setAdEffectiveRateDisplay(ad.effective_rate_display)
+      // For float ads on reopen of the same ad, keep last known rate — the WS will
+      // provide the fresh rate. Resetting from the prop would show a stale value
+      // because page.tsx doesn't subscribe to the exchange_rates channel.
+      if (isNewAd || ad.exchange_rate_type !== "float") {
+        setAdEffectiveRateDisplay(ad.effective_rate_display)
+      }
     }
     if (!isOpen) {
       setShowAdvertChangedAlert(false)

--- a/components/buy-sell/order-sidebar.tsx
+++ b/components/buy-sell/order-sidebar.tsx
@@ -246,18 +246,27 @@ export default function OrderSidebar({ isOpen, onClose, onStartClose, ad, orderT
         if (data?.payload?.data?.event === "update" && data?.payload?.data?.advert) {
           const updatedAdvert = data.payload.data.advert
           if (ad.id == updatedAdvert.id) {
+            const updatedFields: string[] = data.payload.data.updated_fields || []
+
+            if (updatedFields.includes("version")) ad.version = updatedAdvert.version
+            if (updatedFields.includes("minimum_order_amount")) ad.minimum_order_amount = updatedAdvert.minimum_order_amount
+            if (updatedFields.includes("maximum_order_amount")) ad.maximum_order_amount = updatedAdvert.maximum_order_amount
+            if (updatedFields.includes("actual_maximum_order_amount")) ad.actual_maximum_order_amount = updatedAdvert.actual_maximum_order_amount
+            if (updatedFields.includes("order_expiry_period")) ad.order_expiry_period = updatedAdvert.order_expiry_period
+            if (updatedFields.includes("description")) ad.description = updatedAdvert.description
+
             if (ad.exchange_rate_type === "float") {
               setMarketRate(updatedAdvert.effective_rate)
               ad.effective_rate_display = updatedAdvert.effective_rate_display
             }
 
-            const newMethods: string[] = updatedAdvert.payment_methods || []
-            const currentMethods = currentPaymentMethodsRef.current
-            const hasChanged =
-              newMethods.length !== currentMethods.length ||
-              newMethods.some((m) => !currentMethods.includes(m))
-            if (hasChanged) {
+            if (updatedFields.includes("payment_method_names")) {
+              const newMethods: string[] = updatedAdvert.payment_methods || []
+              ad.payment_method_names = updatedAdvert.payment_method_names || ad.payment_method_names
+              currentPaymentMethodsRef.current = newMethods
               setAdPaymentMethods(newMethods)
+              setSelectedPaymentMethods([])
+              setTempSelectedPaymentMethods([])
               setShowPaymentMethodChangedAlert(true)
             }
           }
@@ -285,9 +294,6 @@ export default function OrderSidebar({ isOpen, onClose, onStartClose, ad, orderT
     }
   }, [ad?.id, isOpen])
 
-  useEffect(() => {
-    currentPaymentMethodsRef.current = adPaymentMethods
-  }, [adPaymentMethods])
 
 
   useEffect(() => {
@@ -371,7 +377,7 @@ export default function OrderSidebar({ isOpen, onClose, onStartClose, ad, orderT
       const numAmount = Number.parseFloat(amount)
 
       const rateToUse = lockedConfirmationRate || marketRate
-      const order = await createOrder(ad.id, rateToUse, numAmount, selectedPaymentMethods)
+      const order = await createOrder(ad.id, rateToUse, numAmount, selectedPaymentMethods, ad.version)
       if (order.errors.length > 0) {
         const errorCode = order.errors[0].code
         if (errorCode === "OrderExists") {
@@ -387,6 +393,13 @@ export default function OrderSidebar({ isOpen, onClose, onStartClose, ad, orderT
             onCancel: () => {
               router.push("/orders/" + order.errors[0].detail.order_id)
             }
+          })
+        } else if (errorCode === "OrderAdvertVersionChanged") {
+          showAlert({
+            title: "Ad updated",
+            description: "This ad changed after you opened it. Review the latest details before placing your order.",
+            confirmText: "Review changes",
+            type: "warning",
           })
         } else if (errorCode === "OrderFloatRateSlippage") {
           showAlert({

--- a/components/buy-sell/order-sidebar.tsx
+++ b/components/buy-sell/order-sidebar.tsx
@@ -223,6 +223,7 @@ export default function OrderSidebar({ isOpen, onClose, onStartClose, ad, orderT
   const [adEffectiveRateDisplay, setAdEffectiveRateDisplay] = useState<number | string | undefined>(ad?.effective_rate_display)
   const adRef = useRef(ad)
   useEffect(() => { adRef.current = ad }, [ad])
+  const baseRateRef = useRef<number | undefined>(undefined)
 
   // Use React Query hooks
   const addPaymentMethod = useAddPaymentMethod()
@@ -320,6 +321,7 @@ export default function OrderSidebar({ isOpen, onClose, onStartClose, ad, orderT
       setAdOrderExpiryPeriod(ad.order_expiry_period ?? 0)
       setAdDescription(ad.description ?? "")
       setAdEffectiveRateDisplay(ad.effective_rate_display)
+      baseRateRef.current = Number(Number(ad.effective_rate_display).toFixed(6))
     }
     if (!isOpen) {
       setShowAdvertChangedAlert(false)
@@ -327,6 +329,7 @@ export default function OrderSidebar({ isOpen, onClose, onStartClose, ad, orderT
       setMarketRate(null)
       setShowRateChangeConfirmation(false)
       setLockedConfirmationRate(null)
+      baseRateRef.current = undefined
     }
   }, [ad?.id, isOpen])
 
@@ -393,7 +396,7 @@ export default function OrderSidebar({ isOpen, onClose, onStartClose, ad, orderT
   const handleSubmit = async () => {
     if (!ad) return
 
-    if (ad.exchange_rate_type == "float" && marketRate && Number(marketRate.toFixed(6)) !== Number(Number(adEffectiveRateDisplay).toFixed(6))) {
+    if (ad.exchange_rate_type == "float" && marketRate && baseRateRef.current !== undefined && Number(marketRate.toFixed(6)) !== Number(baseRateRef.current.toFixed(6))) {
       setLockedConfirmationRate(marketRate)
       setShowRateChangeConfirmation(true)
       return
@@ -414,6 +417,11 @@ export default function OrderSidebar({ isOpen, onClose, onStartClose, ad, orderT
       setIsSubmitting(true)
       setOrderStatus(null)
       setShowRateChangeConfirmation(false)
+      baseRateRef.current = lockedConfirmationRate !== null
+        ? Number(lockedConfirmationRate.toFixed(6))
+        : marketRate !== null
+          ? Number(marketRate.toFixed(6))
+          : baseRateRef.current
 
       const numAmount = Number.parseFloat(amount)
 
@@ -807,7 +815,7 @@ export default function OrderSidebar({ isOpen, onClose, onStartClose, ad, orderT
           amount={amount || "0"}
           accountCurrency={ad.account_currency}
           paymentCurrency={ad.payment_currency}
-          oldRate={Number(adEffectiveRateDisplay)}
+          oldRate={baseRateRef.current ?? Number(adEffectiveRateDisplay)}
           newRate={lockedConfirmationRate}
           isBuy={isBuy}
         />

--- a/components/buy-sell/order-sidebar.tsx
+++ b/components/buy-sell/order-sidebar.tsx
@@ -376,14 +376,14 @@ export default function OrderSidebar({ isOpen, onClose, onStartClose, ad, orderT
   const handleSubmit = async () => {
     if (!ad) return
 
-    if (advertChanged) {
-      setShowAdvertChangedAlert(true)
+    if (ad.exchange_rate_type == "float" && marketRate && marketRate != Number(adEffectiveRateDisplay)) {
+      setLockedConfirmationRate(marketRate)
+      setShowRateChangeConfirmation(true)
       return
     }
 
-    if (ad.exchange_rate_type == "float" && marketRate && marketRate != ad.effective_rate) {
-      setLockedConfirmationRate(marketRate)
-      setShowRateChangeConfirmation(true)
+    if (advertChanged) {
+      setShowAdvertChangedAlert(true)
       return
     }
 

--- a/components/buy-sell/order-sidebar.tsx
+++ b/components/buy-sell/order-sidebar.tsx
@@ -776,7 +776,10 @@ export default function OrderSidebar({ isOpen, onClose, onStartClose, ad, orderT
       {ad && (
         <AdvertChangedAlert
           isOpen={showAdvertChangedAlert}
-          onReview={() => { setShowAdvertChangedAlert(false); setAdvertChanged(false) }}
+          onReview={() => {
+            setShowAdvertChangedAlert(false)
+            setAdvertChanged(false)
+          }}
         />
       )}
 
@@ -791,7 +794,7 @@ export default function OrderSidebar({ isOpen, onClose, onStartClose, ad, orderT
           amount={amount || "0"}
           accountCurrency={ad.account_currency}
           paymentCurrency={ad.payment_currency}
-          oldRate={ad.effective_rate}
+          oldRate={Number(adEffectiveRateDisplay)}
           newRate={lockedConfirmationRate}
           isBuy={isBuy}
         />

--- a/components/buy-sell/order-sidebar.tsx
+++ b/components/buy-sell/order-sidebar.tsx
@@ -224,6 +224,9 @@ export default function OrderSidebar({ isOpen, onClose, onStartClose, ad, orderT
   const adRef = useRef(ad)
   useEffect(() => { adRef.current = ad }, [ad])
   const baseRateRef = useRef<number | undefined>(undefined)
+  const adEffectiveRateDisplayRef = useRef(adEffectiveRateDisplay)
+  useEffect(() => { adEffectiveRateDisplayRef.current = adEffectiveRateDisplay }, [adEffectiveRateDisplay])
+  const prevAdIdRef = useRef<number | undefined>(undefined)
 
   // Use React Query hooks
   const addPaymentMethod = useAddPaymentMethod()
@@ -311,6 +314,9 @@ export default function OrderSidebar({ isOpen, onClose, onStartClose, ad, orderT
 
   useEffect(() => {
     if (ad && isOpen) {
+      const isNewAd = prevAdIdRef.current !== ad.id
+      prevAdIdRef.current = ad.id
+
       const methods = ad.payment_methods || []
       setAdPaymentMethods(methods)
       currentPaymentMethodsRef.current = methods
@@ -320,8 +326,13 @@ export default function OrderSidebar({ isOpen, onClose, onStartClose, ad, orderT
       setAdActualMaxOrderAmount(ad.actual_maximum_order_amount ?? "0.00")
       setAdOrderExpiryPeriod(ad.order_expiry_period ?? 0)
       setAdDescription(ad.description ?? "")
-      setAdEffectiveRateDisplay(ad.effective_rate_display)
-      baseRateRef.current = Number(Number(ad.effective_rate_display).toFixed(6))
+
+      if (isNewAd) {
+        setAdEffectiveRateDisplay(ad.effective_rate_display)
+        baseRateRef.current = Number(Number(ad.effective_rate_display).toFixed(6))
+      } else {
+        baseRateRef.current = Number(Number(adEffectiveRateDisplayRef.current).toFixed(6))
+      }
     }
     if (!isOpen) {
       setShowAdvertChangedAlert(false)

--- a/components/buy-sell/payment-method-changed-alert.tsx
+++ b/components/buy-sell/payment-method-changed-alert.tsx
@@ -1,0 +1,48 @@
+"use client"
+
+import { Button } from "@/components/ui/button"
+import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog"
+import { Drawer, DrawerContent, DrawerTitle } from "@/components/ui/drawer"
+import { useIsMobile } from "@/lib/hooks/use-is-mobile"
+
+interface PaymentMethodChangedAlertProps {
+  isOpen: boolean
+  onReview: () => void
+}
+
+export default function PaymentMethodChangedAlert({ isOpen, onReview }: PaymentMethodChangedAlertProps) {
+  const isMobile = useIsMobile()
+
+  const content = (
+    <div className="flex flex-col gap-8">
+      <p className="text-grayscale-100 text-base">
+        The advertiser updated the payment method. Review the details before placing your order.
+      </p>
+      <Button onClick={onReview} className="w-full">
+        Review changes
+      </Button>
+    </div>
+  )
+
+  if (!isOpen) return null
+
+  if (isMobile) {
+    return (
+      <Drawer open={isOpen} onOpenChange={(open) => !open && onReview()}>
+        <DrawerContent className="px-6 pb-8">
+          <DrawerTitle className="text-2xl font-bold my-4">Payment method changed</DrawerTitle>
+          {content}
+        </DrawerContent>
+      </Drawer>
+    )
+  }
+
+  return (
+    <Dialog open={isOpen} onOpenChange={(open) => !open && onReview()}>
+      <DialogContent className="p-[32px] sm:rounded-[32px]">
+        <DialogTitle className="font-bold text-2xl mb-4">Payment method changed</DialogTitle>
+        {content}
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/services/api/api-buy-sell.ts
+++ b/services/api/api-buy-sell.ts
@@ -36,6 +36,7 @@ export interface Advertisement {
   user_rating_average?: number
   effective_rate_display?: number
   is_private?: boolean
+  version?: number
 }
 
 // Define the SearchParams interface

--- a/services/api/api-orders.ts
+++ b/services/api/api-orders.ts
@@ -281,7 +281,7 @@ export async function disputeOrder(orderId: string, reason: string): Promise<{ s
   }
 }
 
-export async function createOrder(advertId: number, exchangeRate: number, amount: number, paymentMethodIds: []): Promise<Order> {
+export async function createOrder(advertId: number, exchangeRate: number, amount: number, paymentMethodIds: [], advertVersion?: number): Promise<Order> {
   try {
     const url = `${API.baseUrl}${API.endpoints.orders}`
     const headers = {
@@ -295,6 +295,7 @@ export async function createOrder(advertId: number, exchangeRate: number, amount
         amount: amount,
         ...(exchangeRate && { exchange_rate: exchangeRate }),
         ...(paymentMethodIds.length > 0 && { payment_method_ids: paymentMethodIds }),
+        ...(advertVersion !== undefined && { advert_version: advertVersion }),
       },
     })
 


### PR DESCRIPTION
## 🚀 Description
Adds real-time advert change detection to the order sidebar: while the order modal is open, incoming WebSocket updates to the ad's fields are applied live and the user is prompted to review before placing their order. The `advert_version` is now sent with every order creation request so the server can detect stale orders.

## 📋 Changes

### New Components
- `components/buy-sell/advert-changed-alert.tsx` — Responsive Dialog/Drawer alert ("Ad updated") shown when the user attempts to place an order after the ad was modified. Mirrors the existing `RateChangeConfirmation` pattern.

### `components/buy-sell/order-sidebar.tsx`
- Broadened the existing WebSocket subscription to run for all ads (not just floating-rate), while keeping exchange-rate logic gated behind the float check.
- On `adverts/currency/` update events, selectively applies changes from `updated_fields` to the live `ad` object: `version`, `minimum_order_amount`, `maximum_order_amount`, `actual_maximum_order_amount`, `order_expiry_period`, `description`, and `payment_method_names` / `payment_methods`.
- Introduced `adPaymentMethods` local state so payment method changes (including clearing the user's selection) are reflected in the UI without requiring a prop change from the parent.
- Sets `advertChanged = true` for any non-rate field change; rate-only updates (`exchange_rate`, `effective_rate`, `effective_rate_display`) continue to be handled exclusively by `RateChangeConfirmation`.
- `handleSubmit` checks `advertChanged` before the rate-change check — if set, surfaces `AdvertChangedAlert` and returns early; the flag is cleared once the user dismisses the alert.
- Handles `OrderAdvertVersionChanged` API error with the same "Ad updated" alert via `showAlert`.
- Passes `ad.version` as `advert_version` to `createOrder`.

### `app/page.tsx`
- Updated the market-list WebSocket handler to apply all `updated_fields` (limits, expiry, description, payment methods, version) to the local adverts state, keeping the list in sync with live ad changes.

### `services/api/api-buy-sell.ts`
- Added optional `version?: number` field to the `Advertisement` interface.

### `services/api/api-orders.ts`
- Added optional `advertVersion` parameter to `createOrder`; included as `advert_version` in the request body when present.