### PR TITLE
Ameerul / ENGT-6775 Show last seen in markets

### DIFF
--- a/__tests__/components/presence-last-seen.test.tsx
+++ b/__tests__/components/presence-last-seen.test.tsx
@@ -1,0 +1,199 @@
+import { render, screen } from "@testing-library/react"
+import jest from "jest"
+import { formatLastSeen } from "@/components/presence-last-seen"
+import { PresenceLastSeen } from "@/components/presence-last-seen"
+
+jest.mock("@/lib/i18n/use-translations", () => ({
+  useTranslations: () => ({
+    t: (key: string, params?: Record<string, string | number>) => {
+      const map: Record<string, string> = {
+        "presence.seenJustNow": "Seen just now",
+        "presence.seenMinutesAgo": "Seen {count} minute{plural} ago",
+        "presence.seenHoursAgo": "Seen {count} hour{plural} ago",
+        "presence.seenDaysAgo": "Seen {count} day{plural} ago",
+        "presence.seenMonthsAgo": "Seen {count} month{plural} ago",
+        "presence.seenMoreThanSixMonthsAgo": "Seen more than 6 months ago",
+      }
+      let value = map[key] ?? key
+      if (params) {
+        Object.entries(params).forEach(([k, v]) => {
+          value = value.replace(`{${k}}`, String(v))
+        })
+      }
+      return value
+    },
+    locale: "en",
+  }),
+}))
+
+const mockNow = new Date("2024-06-01T12:00:00Z").getTime()
+
+const t = (key: string, params?: Record<string, string | number>) => {
+  const map: Record<string, string> = {
+    "presence.seenJustNow": "Seen just now",
+    "presence.seenMinutesAgo": "Seen {count} minute{plural} ago",
+    "presence.seenHoursAgo": "Seen {count} hour{plural} ago",
+    "presence.seenDaysAgo": "Seen {count} day{plural} ago",
+    "presence.seenMonthsAgo": "Seen {count} month{plural} ago",
+    "presence.seenMoreThanSixMonthsAgo": "Seen more than 6 months ago",
+  }
+  let value = map[key] ?? key
+  if (params) {
+    Object.entries(params).forEach(([k, v]) => {
+      value = value.replace(`{${k}}`, String(v))
+    })
+  }
+  return value
+}
+
+describe("formatLastSeen", () => {
+  beforeEach(() => {
+    jest.spyOn(Date, "now").mockReturnValue(mockNow)
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  describe("null / missing timestamps", () => {
+    it("returns empty string for null", () => {
+      expect(formatLastSeen(null, t)).toBe("")
+    })
+
+    it("returns empty string for undefined", () => {
+      expect(formatLastSeen(undefined, t)).toBe("")
+    })
+
+    it("returns empty string for 0 (falsy epoch)", () => {
+      // 0 is treated as missing — valid as per the null-check
+      expect(formatLastSeen(0, t)).toBe("")
+    })
+
+    it("returns just-now for a future timestamp (clocks slightly ahead)", () => {
+      const future = mockNow + 5000
+      expect(formatLastSeen(future, t)).toBe("Seen just now")
+    })
+  })
+
+  describe("just now (< 1 minute)", () => {
+    it("returns 'Seen just now' for 30 seconds ago", () => {
+      expect(formatLastSeen(mockNow - 30 * 1000, t)).toBe("Seen just now")
+    })
+
+    it("returns 'Seen just now' for 59 seconds ago", () => {
+      expect(formatLastSeen(mockNow - 59 * 1000, t)).toBe("Seen just now")
+    })
+  })
+
+  describe("minutes (1–59)", () => {
+    it("returns singular '1 minute' for exactly 1 minute ago", () => {
+      expect(formatLastSeen(mockNow - 60 * 1000, t)).toBe("Seen 1 minute ago")
+    })
+
+    it("returns plural '5 minutes' for 5 minutes ago", () => {
+      expect(formatLastSeen(mockNow - 5 * 60 * 1000, t)).toBe("Seen 5 minutes ago")
+    })
+
+    it("returns '59 minutes' for 59 minutes ago", () => {
+      expect(formatLastSeen(mockNow - 59 * 60 * 1000, t)).toBe("Seen 59 minutes ago")
+    })
+  })
+
+  describe("hours (1–23)", () => {
+    it("returns singular '1 hour' for exactly 1 hour ago", () => {
+      expect(formatLastSeen(mockNow - 60 * 60 * 1000, t)).toBe("Seen 1 hour ago")
+    })
+
+    it("returns plural '3 hours' for 3 hours ago", () => {
+      expect(formatLastSeen(mockNow - 3 * 60 * 60 * 1000, t)).toBe("Seen 3 hours ago")
+    })
+
+    it("returns '23 hours' for 23 hours ago", () => {
+      expect(formatLastSeen(mockNow - 23 * 60 * 60 * 1000, t)).toBe("Seen 23 hours ago")
+    })
+  })
+
+  describe("days (1–29)", () => {
+    it("returns singular '1 day' for exactly 1 day ago", () => {
+      expect(formatLastSeen(mockNow - 24 * 60 * 60 * 1000, t)).toBe("Seen 1 day ago")
+    })
+
+    it("returns plural '7 days' for 7 days ago", () => {
+      expect(formatLastSeen(mockNow - 7 * 24 * 60 * 60 * 1000, t)).toBe("Seen 7 days ago")
+    })
+
+    it("returns '29 days' for 29 days ago", () => {
+      expect(formatLastSeen(mockNow - 29 * 24 * 60 * 60 * 1000, t)).toBe("Seen 29 days ago")
+    })
+  })
+
+  describe("months (1–6)", () => {
+    it("returns singular '1 month' for ~30 days ago", () => {
+      expect(formatLastSeen(mockNow - 30 * 24 * 60 * 60 * 1000, t)).toBe("Seen 1 month ago")
+    })
+
+    it("returns plural '3 months' for ~90 days ago", () => {
+      expect(formatLastSeen(mockNow - 90 * 24 * 60 * 60 * 1000, t)).toBe("Seen 3 months ago")
+    })
+
+    it("returns '6 months' for ~180 days ago", () => {
+      expect(formatLastSeen(mockNow - 180 * 24 * 60 * 60 * 1000, t)).toBe("Seen 6 months ago")
+    })
+  })
+
+  describe("more than 6 months", () => {
+    it("returns 'Seen more than 6 months ago' for ~7 months ago", () => {
+      expect(formatLastSeen(mockNow - 210 * 24 * 60 * 60 * 1000, t)).toBe("Seen more than 6 months ago")
+    })
+
+    it("returns 'Seen more than 6 months ago' for 2 years ago", () => {
+      expect(formatLastSeen(mockNow - 730 * 24 * 60 * 60 * 1000, t)).toBe("Seen more than 6 months ago")
+    })
+  })
+})
+
+describe("PresenceLastSeen", () => {
+  beforeEach(() => {
+    jest.spyOn(Date, "now").mockReturnValue(mockNow)
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  it("renders nothing when user is online", () => {
+    const { container } = render(
+      <PresenceLastSeen isOnline={true} lastOnlineAt={mockNow - 10 * 60 * 1000} />,
+    )
+    expect(container.firstChild).toBeNull()
+  })
+
+  it("renders nothing when lastOnlineAt is null", () => {
+    const { container } = render(<PresenceLastSeen isOnline={false} lastOnlineAt={null} />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it("renders nothing when lastOnlineAt is undefined", () => {
+    const { container } = render(<PresenceLastSeen isOnline={false} />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it("renders last-seen text when offline with timestamp", () => {
+    render(<PresenceLastSeen isOnline={false} lastOnlineAt={mockNow - 5 * 60 * 1000} />)
+    expect(screen.getByText("Seen 5 minutes ago")).toBeInTheDocument()
+  })
+
+  it("applies default className when none provided", () => {
+    const { container } = render(
+      <PresenceLastSeen isOnline={false} lastOnlineAt={mockNow - 60 * 1000} />,
+    )
+    expect(container.firstChild).toHaveClass("text-xs", "text-grayscale-600")
+  })
+
+  it("applies custom className when provided", () => {
+    const { container } = render(
+      <PresenceLastSeen isOnline={false} lastOnlineAt={mockNow - 60 * 1000} className="custom-class" />,
+    )
+    expect(container.firstChild).toHaveClass("custom-class")
+  })
+})

--- a/app/advertiser/[id]/page.tsx
+++ b/app/advertiser/[id]/page.tsx
@@ -28,6 +28,7 @@ import { AdvertiserSkeleton } from "@/app/advertiser/components/advertiser-skele
 import { useAdvertiserAds, queryKeys } from "@/hooks/use-api-queries"
 import { useQueryClient } from "@tanstack/react-query"
 import { useWebSocketContext } from "@/contexts/websocket-context"
+import { PresenceLastSeen } from "@/components/presence-last-seen"
 
 interface AdvertiserProfile {
   id: string | number
@@ -41,6 +42,7 @@ interface AdvertiserProfile {
   is_blocked: boolean
   is_favourite: boolean
   is_online?: boolean
+  last_online_at?: number | null
   temp_ban_until: number | null
   trade_band: string
   order_count_lifetime: number
@@ -175,9 +177,15 @@ export default function AdvertiserProfilePage({ onBack }: AdvertiserProfilePageP
 
   const handleUsersOnlineUpdate = useCallback((data: any) => {
     if (data?.options?.channel === "users_online") {
-      const update: { user_id: number; is_online: boolean } | null = data?.payload?.data ?? null
+      const update: { user_id: number; is_online: boolean; last_online_at?: number | null } | null = data?.payload?.data ?? null
       if (update && String(update.user_id) === String(currentIdRef.current)) {
-        setProfile((prev) => prev ? { ...prev, is_online: update.is_online } : prev)
+        setProfile((prev) => {
+          if (!prev) return prev
+          const lastOnlineAt = update.is_online
+            ? prev.last_online_at
+            : (update.last_online_at ?? Date.now())
+          return { ...prev, is_online: update.is_online, last_online_at: lastOnlineAt }
+        })
       }
     }
   }, [])
@@ -450,11 +458,19 @@ export default function AdvertiserProfilePage({ onBack }: AdvertiserProfilePageP
                       }
                     </div>
                     <div className="flex items-center text-xs text-grayscale-600 mt-2">
-                      <span className="mr-[8px]">
-                        {profile?.is_online ? t("advertiser.online") : t("advertiser.offline")}
+                      {!profile?.is_online && profile?.last_online_at && (
+                        <>
+                          <PresenceLastSeen
+                            isOnline={profile.is_online}
+                            lastOnlineAt={profile.last_online_at}
+                            className="text-xs text-grayscale-600 mr-[8px]"
+                          />
+                          <span className="opacity-[0.08]">|</span>
+                        </>
+                      )}
+                      <span className={!profile?.is_online && profile?.last_online_at ? "ml-[8px]" : ""}>
+                        {profile ? getJoinedDate(profile.created_at) : ""}
                       </span>
-                      <span className="opacity-[0.08]">|</span>
-                      <span className="ml-[8px]">{profile ? getJoinedDate(profile.created_at) : ""}</span>
                     </div>
                     <div className="flex items-center text-xs text-grayscale-600 mt-2 gap-2">
                       <div className="flex items-center">

--- a/app/advertiser/[id]/page.tsx
+++ b/app/advertiser/[id]/page.tsx
@@ -30,6 +30,13 @@ import { useQueryClient } from "@tanstack/react-query"
 import { useWebSocketContext } from "@/contexts/websocket-context"
 import { PresenceLastSeen } from "@/components/presence-last-seen"
 
+interface UsersOnlineUpdate {
+  user_id: number
+  is_online: boolean
+  /** Server-provided epoch ms timestamp; only present on offline transitions. */
+  last_online_at?: number | null
+}
+
 interface AdvertiserProfile {
   id: string | number
   nickname: string
@@ -175,19 +182,27 @@ export default function AdvertiserProfilePage({ onBack }: AdvertiserProfilePageP
     return () => observer.disconnect()
   }, [hasNextPage, isFetchingNextPage, fetchNextPage])
 
-  const handleUsersOnlineUpdate = useCallback((data: any) => {
-    if (data?.options?.channel === "users_online") {
-      const update: { user_id: number; is_online: boolean; last_online_at?: number | null } | null = data?.payload?.data ?? null
-      if (update && String(update.user_id) === String(currentIdRef.current)) {
-        setProfile((prev) => {
-          if (!prev) return prev
-          const lastOnlineAt = update.is_online
-            ? prev.last_online_at
-            : (update.last_online_at ?? Date.now())
-          return { ...prev, is_online: update.is_online, last_online_at: lastOnlineAt }
-        })
-      }
-    }
+  const handleUsersOnlineUpdate = useCallback((data: unknown) => {
+    if (!data || typeof data !== "object") return
+    const channel = (data as Record<string, any>)?.options?.channel
+    if (channel !== "users_online") return
+
+    const payload = (data as Record<string, any>)?.payload?.data
+    if (!payload || typeof payload.user_id !== "number" || typeof payload.is_online !== "boolean") return
+
+    const update: UsersOnlineUpdate = payload
+
+    if (String(update.user_id) !== String(currentIdRef.current)) return
+
+    setProfile((prev) => {
+      if (!prev) return prev
+      // Prefer server-provided timestamp; fall back to Date.now() only as a
+      // last resort so the UI immediately reflects the offline state.
+      const lastOnlineAt = update.is_online
+        ? prev.last_online_at
+        : (update.last_online_at ?? Date.now())
+      return { ...prev, is_online: update.is_online, last_online_at: lastOnlineAt }
+    })
   }, [])
 
   useEffect(() => {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -35,6 +35,7 @@ import { VerifiedBadge } from "@/components/verified-badge"
 import { Skeleton } from "@/components/ui/skeleton"
 import { useWebSocketContext } from "@/contexts/websocket-context"
 import { useIsMobile } from "@/hooks/use-mobile"
+import { PresenceLastSeen } from "@/components/presence-last-seen"
 
 type Ad = Advertisement
 type AdType = "buy" | "sell"
@@ -399,12 +400,16 @@ export default function BuySellPage() {
 
   const handleUsersOnlineUpdate = useCallback((data: any) => {
     if (data?.options?.channel === "users_online") {
-      const update: { user_id: number; is_online: boolean } | null = data?.payload?.data ?? null
+      const update: { user_id: number; is_online: boolean; last_online_at?: number | null } | null = data?.payload?.data ?? null
       if (update) {
         setAdverts((currentAdverts) =>
-          currentAdverts.map((ad) =>
-            update.user_id === ad.user?.id ? { ...ad, user: { ...ad.user, is_online: update.is_online } } : ad,
-          ),
+          currentAdverts.map((ad) => {
+            if (update.user_id !== ad.user?.id) return ad
+            const lastOnlineAt = update.is_online
+              ? ad.user.last_online_at
+              : (update.last_online_at ?? Date.now())
+            return { ...ad, user: { ...ad.user, is_online: update.is_online, last_online_at: lastOnlineAt } }
+          }),
         )
       }
     }
@@ -740,6 +745,11 @@ export default function BuySellPage() {
                             )}
                           </div>
                         </div>
+                        <PresenceLastSeen
+                          isOnline={ad.user?.is_online}
+                          lastOnlineAt={ad.user?.last_online_at}
+                          className="text-xs text-slate-500 mt-[2px] block"
+                        />
                         <div className="flex items-center text-xs text-slate-500 mt-[4px]">
                           {ad.user.rating_average_lifetime && (
                             <span className="flex items-center">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -40,6 +40,13 @@ import { PresenceLastSeen } from "@/components/presence-last-seen"
 type Ad = Advertisement
 type AdType = "buy" | "sell"
 
+interface UsersOnlineUpdate {
+  user_id: number
+  is_online: boolean
+  /** Server-provided epoch ms timestamp; only present on offline transitions. */
+  last_online_at?: number | null
+}
+
 
 export default function BuySellPage() {
   const { t, locale } = useTranslations()
@@ -398,21 +405,27 @@ export default function BuySellPage() {
     return unsubscribe
   }, [subscribe])
 
-  const handleUsersOnlineUpdate = useCallback((data: any) => {
-    if (data?.options?.channel === "users_online") {
-      const update: { user_id: number; is_online: boolean; last_online_at?: number | null } | null = data?.payload?.data ?? null
-      if (update) {
-        setAdverts((currentAdverts) =>
-          currentAdverts.map((ad) => {
-            if (update.user_id !== ad.user?.id) return ad
-            const lastOnlineAt = update.is_online
-              ? ad.user.last_online_at
-              : (update.last_online_at ?? Date.now())
-            return { ...ad, user: { ...ad.user, is_online: update.is_online, last_online_at: lastOnlineAt } }
-          }),
-        )
-      }
-    }
+  const handleUsersOnlineUpdate = useCallback((data: unknown) => {
+    if (!data || typeof data !== "object") return
+    const channel = (data as Record<string, any>)?.options?.channel
+    if (channel !== "users_online") return
+
+    const payload = (data as Record<string, any>)?.payload?.data
+    if (!payload || typeof payload.user_id !== "number" || typeof payload.is_online !== "boolean") return
+
+    const update: UsersOnlineUpdate = payload
+
+    setAdverts((currentAdverts) =>
+      currentAdverts.map((ad) => {
+        if (update.user_id !== ad.user?.id) return ad
+        // Prefer server-provided timestamp; fall back to Date.now() only as a
+        // last resort so the UI immediately reflects the offline state.
+        const lastOnlineAt = update.is_online
+          ? ad.user.last_online_at
+          : (update.last_online_at ?? Date.now())
+        return { ...ad, user: { ...ad.user, is_online: update.is_online, last_online_at: lastOnlineAt } }
+      }),
+    )
   }, [])
 
   useEffect(() => {

--- a/components/advertiser-search-result-card.tsx
+++ b/components/advertiser-search-result-card.tsx
@@ -9,6 +9,7 @@ import { formatPaymentMethodName } from "@/lib/utils"
 import { useTranslations } from "@/lib/i18n/use-translations"
 import type { Advertisement } from "@/services/api/api-buy-sell"
 import { useUserDataStore } from "@/stores/user-data-store"
+import { PresenceLastSeen } from "@/components/presence-last-seen"
 
 interface AdvertiserSearchResultCardProps {
     ad: Advertisement
@@ -51,6 +52,11 @@ export function AdvertiserSearchResultCard({ ad, onAdvertiserClick, onBuySellCli
                     </div>
                 </div>
             </div>
+            <PresenceLastSeen
+                isOnline={ad.user?.is_online}
+                lastOnlineAt={ad.user?.last_online_at}
+                className="text-xs text-slate-500 mt-[2px] mb-[2px] block"
+            />
             <div className="flex items-center text-xs text-slate-500 mb-2">
                 {ad.user.rating_average_lifetime && (
                     <span className="flex items-center">

--- a/components/presence-last-seen.tsx
+++ b/components/presence-last-seen.tsx
@@ -1,0 +1,69 @@
+"use client"
+
+import { useTranslations } from "@/lib/i18n/use-translations"
+
+type TranslateFn = (key: string, params?: Record<string, string | number>) => string
+
+export function formatLastSeen(lastOnlineAt: number | null | undefined, t: TranslateFn): string {
+  if (!lastOnlineAt) return ""
+
+  const diffMs = Date.now() - lastOnlineAt
+  const minutes = Math.floor(diffMs / 60000)
+
+  if (minutes < 1) return t("presence.seenJustNow")
+
+  if (minutes < 60) {
+    return t("presence.seenMinutesAgo", {
+      count: minutes,
+      plural: minutes === 1 ? "" : "s",
+    })
+  }
+
+  const hours = Math.floor(minutes / 60)
+  if (hours < 24) {
+    return t("presence.seenHoursAgo", {
+      count: hours,
+      plural: hours === 1 ? "" : "s",
+    })
+  }
+
+  const days = Math.floor(hours / 24)
+  if (days < 30) {
+    return t("presence.seenDaysAgo", {
+      count: days,
+      plural: days === 1 ? "" : "s",
+    })
+  }
+
+  const months = Math.round(days / 30.44)
+  if (months <= 6) {
+    const clamped = Math.max(1, months)
+    return t("presence.seenMonthsAgo", {
+      count: clamped,
+      plural: clamped === 1 ? "" : "s",
+    })
+  }
+
+  return t("presence.seenMoreThanSixMonthsAgo")
+}
+
+interface PresenceLastSeenProps {
+  isOnline?: boolean
+  lastOnlineAt?: number | null
+  className?: string
+}
+
+export function PresenceLastSeen({ isOnline, lastOnlineAt, className }: PresenceLastSeenProps) {
+  const { t } = useTranslations()
+
+  if (isOnline) return null
+
+  const text = formatLastSeen(lastOnlineAt, t)
+  if (!text) return null
+
+  return (
+    <span className={className ?? "text-xs text-grayscale-600"}>
+      {text}
+    </span>
+  )
+}

--- a/components/presence-last-seen.tsx
+++ b/components/presence-last-seen.tsx
@@ -4,8 +4,11 @@ import { useTranslations } from "@/lib/i18n/use-translations"
 
 type TranslateFn = (key: string, params?: Record<string, string | number>) => string
 
+/** Average days per month accounting for leap years. */
+const AVG_DAYS_PER_MONTH = 30.44
+
 export function formatLastSeen(lastOnlineAt: number | null | undefined, t: TranslateFn): string {
-  if (!lastOnlineAt) return ""
+  if (lastOnlineAt == null) return ""
 
   const diffMs = Date.now() - lastOnlineAt
   const minutes = Math.floor(diffMs / 60000)
@@ -35,7 +38,7 @@ export function formatLastSeen(lastOnlineAt: number | null | undefined, t: Trans
     })
   }
 
-  const months = Math.round(days / 30.44)
+  const months = Math.round(days / AVG_DAYS_PER_MONTH)
   if (months <= 6) {
     const clamped = Math.max(1, months)
     return t("presence.seenMonthsAgo", {

--- a/lib/i18n/translations/bn.json
+++ b/lib/i18n/translations/bn.json
@@ -694,5 +694,13 @@
     "errorTitle": "কিছু ভুল হয়েছে।",
     "errorMessage": "ত্রুটি কোড: {errorCode}। অনুগ্রহ করে পরে আবার চেষ্টা করুন অথবা সহায়তার সঙ্গে যোগাযোগ করুন।",
     "validationError": "শুধুমাত্র অক্ষর, সংখ্যা, স্পেস এবং নিম্নলিখিত বিশেষ চিহ্নগুলো অনুমোদিত: @ - . ! / % & , _ ( ) + : ;"
+  },
+  "presence": {
+    "seenJustNow": "এইমাত্র দেখা গেছে",
+    "seenMinutesAgo": "{count} মিনিট আগে দেখা গেছে",
+    "seenHoursAgo": "{count} ঘণ্টা আগে দেখা গেছে",
+    "seenDaysAgo": "{count} দিন আগে দেখা গেছে",
+    "seenMonthsAgo": "{count} মাস আগে দেখা গেছে",
+    "seenMoreThanSixMonthsAgo": "৬ মাসেরও বেশি আগে দেখা গেছে"
   }
 }

--- a/lib/i18n/translations/de.json
+++ b/lib/i18n/translations/de.json
@@ -715,5 +715,13 @@
     "errorTitle": "Etwas ist schiefgelaufen.",
     "errorMessage": "Fehlercode: {errorCode}. Bitte versuchen Sie es später erneut oder kontaktieren Sie den Support.",
     "validationError": "Nur Buchstaben, Zahlen, Leerzeichen und die folgenden Sonderzeichen sind erlaubt: @ - . ! / % & , _ ( ) + : ;"
+  },
+  "presence": {
+    "seenJustNow": "Gerade eben gesehen",
+    "seenMinutesAgo": "Vor {count} Minute{plural} gesehen",
+    "seenHoursAgo": "Vor {count} Stunde{plural} gesehen",
+    "seenDaysAgo": "Vor {count} Tag{plural} gesehen",
+    "seenMonthsAgo": "Vor {count} Monat{plural} gesehen",
+    "seenMoreThanSixMonthsAgo": "Vor mehr als 6 Monaten gesehen"
   }
 }

--- a/lib/i18n/translations/en.json
+++ b/lib/i18n/translations/en.json
@@ -811,5 +811,13 @@
     "errorTitle": "Something went wrong.",
     "errorMessage": "Error code: {errorCode}. Please try again later or contact support.",
     "validationError": "Only letters, numbers, spaces, and the following special characters are allowed: @ - . ! / % & , _ ( ) + : ;"
+  },
+  "presence": {
+    "seenJustNow": "Seen just now",
+    "seenMinutesAgo": "Seen {count} minute{plural} ago",
+    "seenHoursAgo": "Seen {count} hour{plural} ago",
+    "seenDaysAgo": "Seen {count} day{plural} ago",
+    "seenMonthsAgo": "Seen {count} month{plural} ago",
+    "seenMoreThanSixMonthsAgo": "Seen more than 6 months ago"
   }
 }

--- a/lib/i18n/translations/es.json
+++ b/lib/i18n/translations/es.json
@@ -692,5 +692,13 @@
     "errorTitle": "Algo salió mal.",
     "errorMessage": "Código de error: {errorCode}. Inténtalo de nuevo más tarde o contacta con soporte.",
     "validationError": "Solo se permiten letras, números, espacios y los siguientes caracteres especiales: @ - . ! / % & , _ ( ) + : ;"
+  },
+  "presence": {
+    "seenJustNow": "Visto hace un momento",
+    "seenMinutesAgo": "Visto hace {count} minuto{plural}",
+    "seenHoursAgo": "Visto hace {count} hora{plural}",
+    "seenDaysAgo": "Visto hace {count} día{plural}",
+    "seenMonthsAgo": "Visto hace {count} mes{plural}",
+    "seenMoreThanSixMonthsAgo": "Visto hace más de 6 meses"
   }
 }

--- a/lib/i18n/translations/fr.json
+++ b/lib/i18n/translations/fr.json
@@ -686,5 +686,13 @@
     "errorTitle": "Une erreur s'est produite.",
     "errorMessage": "Code d'erreur : {errorCode}. Veuillez réessayer plus tard ou contacter le support.",
     "validationError": "Seules les lettres, les chiffres, les espaces et les caractères spéciaux suivants sont autorisés : @ - . ! / % & , _ ( ) + : ;"
+  },
+  "presence": {
+    "seenJustNow": "Vu il y a un instant",
+    "seenMinutesAgo": "Vu il y a {count} minute{plural}",
+    "seenHoursAgo": "Vu il y a {count} heure{plural}",
+    "seenDaysAgo": "Vu il y a {count} jour{plural}",
+    "seenMonthsAgo": "Vu il y a {count} mois",
+    "seenMoreThanSixMonthsAgo": "Vu il y a plus de 6 mois"
   }
 }

--- a/lib/i18n/translations/it.json
+++ b/lib/i18n/translations/it.json
@@ -689,5 +689,13 @@
     "errorTitle": "Qualcosa è andato storto.",
     "errorMessage": "Codice errore: {errorCode}. Riprova più tardi o contatta l'assistenza.",
     "validationError": "Sono consentiti solo lettere, numeri, spazi e i seguenti caratteri speciali: @ - . ! / % & , _ ( ) + : ;"
+  },
+  "presence": {
+    "seenJustNow": "Visto poco fa",
+    "seenMinutesAgo": "Visto {count} minut{plural} fa",
+    "seenHoursAgo": "Visto {count} ora{plural} fa",
+    "seenDaysAgo": "Visto {count} giorno{plural} fa",
+    "seenMonthsAgo": "Visto {count} mese{plural} fa",
+    "seenMoreThanSixMonthsAgo": "Visto più di 6 mesi fa"
   }
 }

--- a/lib/i18n/translations/ko.json
+++ b/lib/i18n/translations/ko.json
@@ -472,7 +472,7 @@
     "deleteAdOpenOrdersTitle": "광고를 삭제할 수 없습니다",
     "deleteAdOpenOrders": "이 광고에 활성 주문이 있습니다. 주문이 완료되면 삭제할 수 있습니다.",
     "unableToUpdateAd": "광고를 업데이트할 수 없습니다",
-    "updateAdError": "광고를 업데이트할 때 오류가 발생했습니다. 다시 시도하세요.",
+    "updateAdError": "광고를 업데이트할 수 없습니다",
     "advertiserStats": "광고주 통계",
     "orderResponse": "주문 응답",
     "buyerAndSeller": "구매자/판매자",
@@ -480,7 +480,6 @@
     "margin": "마진",
     "advType": "광고 유형",
     "rateType": "환율 유형",
-    "rate": "환율",
     "fixedRate": "고정 환율",
     "floatingRate": "변동 환율",
     "floatingRateTooltip": "+ 또는 -로 설정된 시장 환율의 백분율입니다.",
@@ -510,10 +509,8 @@
     "yourAdWillBePosted": "광고가 게시될 예정입니다.",
     "postAd": "광고 게시",
     "createAdError": "광고를 생성할 수 없습니다",
-    "updateAdError": "광고를 업데이트할 수 없습니다",
     "updateAdTitle": "광고 업데이트",
     "totalLimit": "총 한도",
-    "availableBalance": "사용 가능한 잔액",
     "yourAdvInfo": "광고 정보",
     "editAdvPaymentMethods": "결제 방법 수정",
     "editAdvCountries": "국가 수정",
@@ -538,5 +535,13 @@
     "errorTitle": "문제가 발생했습니다.",
     "errorMessage": "오류 코드: {errorCode}. 나중에 다시 시도하거나 지원팀에 문의하세요.",
     "validationError": "문자, 숫자, 공백 및 다음 특수 문자만 사용할 수 있습니다: @ - . ! / % & , _ ( ) + : ;"
+  },
+  "presence": {
+    "seenJustNow": "방금 접속",
+    "seenMinutesAgo": "{count}분 전 접속",
+    "seenHoursAgo": "{count}시간 전 접속",
+    "seenDaysAgo": "{count}일 전 접속",
+    "seenMonthsAgo": "{count}개월 전 접속",
+    "seenMoreThanSixMonthsAgo": "6개월 이상 전 접속"
   }
 }

--- a/lib/i18n/translations/pl.json
+++ b/lib/i18n/translations/pl.json
@@ -530,5 +530,13 @@
     "errorTitle": "Coś poszło nie tak.",
     "errorMessage": "Kod błędu: {errorCode}. Spróbuj ponownie później lub skontaktuj się z obsługą.",
     "validationError": "Dozwolone są tylko litery, cyfry, spacje oraz następujące znaki specjalne: @ - . ! / % & , _ ( ) + : ;"
+  },
+  "presence": {
+    "seenJustNow": "Widziano przed chwilą",
+    "seenMinutesAgo": "Widziano {count} minut{plural} temu",
+    "seenHoursAgo": "Widziano {count} godzin{plural} temu",
+    "seenDaysAgo": "Widziano {count} dzień{plural} temu",
+    "seenMonthsAgo": "Widziano {count} miesiąc{plural} temu",
+    "seenMoreThanSixMonthsAgo": "Widziano ponad 6 miesięcy temu"
   }
 }

--- a/lib/i18n/translations/pt.json
+++ b/lib/i18n/translations/pt.json
@@ -670,5 +670,13 @@
     "errorTitle": "Algo correu mal.",
     "errorMessage": "Código de erro: {errorCode}. Tente novamente mais tarde ou contacte o apoio ao cliente.",
     "validationError": "Apenas são permitidas letras, números, espaços e os seguintes caracteres especiais: @ - . ! / % & , _ ( ) + : ;"
+  },
+  "presence": {
+    "seenJustNow": "Visto há pouco",
+    "seenMinutesAgo": "Visto há {count} minuto{plural}",
+    "seenHoursAgo": "Visto há {count} hora{plural}",
+    "seenDaysAgo": "Visto há {count} dia{plural}",
+    "seenMonthsAgo": "Visto há {count} mês{plural}",
+    "seenMoreThanSixMonthsAgo": "Visto há mais de 6 meses"
   }
 }

--- a/lib/i18n/translations/ru.json
+++ b/lib/i18n/translations/ru.json
@@ -578,7 +578,6 @@
     "minimumOrderLessThanMaximum": "Минимальный заказ должен быть меньше максимального заказа",
     "selectAtLeastOnePaymentMethod": "Выберите хотя бы один способ оплаты",
     "postAd": "Разместить объявление",
-    "updateAd": "Обновить объявление",
     "creatingAd": "Создание объявления...",
     "updatingAd": "Обновление объявления...",
     "unableToCreateAd": "Не удалось создать объявление",
@@ -607,9 +606,6 @@
     "successfullyUnfollowed": "Успешно отписались",
     "userBlocked": "{nickname} заблокирован.",
     "userUnblocked": "{nickname} разблокирован.",
-    "profile": "Профиль рекламодателя",
-    "stats": "Статистика",
-    "ads": "Объявления",
     "noAds": "Нет доступных объявлений",
     "noAdsDescription": "У этого рекламодателя в настоящее время нет активных объявлений.",
     "loadingProfile": "Загрузка профиля...",
@@ -723,5 +719,13 @@
     "errorTitle": "Что-то пошло не так.",
     "errorMessage": "Код ошибки: {errorCode}. Повторите попытку позже или обратитесь в службу поддержки.",
     "validationError": "Разрешены только буквы, цифры, пробелы и следующие специальные символы: @ - . ! / % & , _ ( ) + : ;"
+  },
+  "presence": {
+    "seenJustNow": "Только что в сети",
+    "seenMinutesAgo": "В сети {count} минут{plural} назад",
+    "seenHoursAgo": "В сети {count} час{plural} назад",
+    "seenDaysAgo": "В сети {count} день{plural} назад",
+    "seenMonthsAgo": "В сети {count} месяц{plural} назад",
+    "seenMoreThanSixMonthsAgo": "В сети более 6 месяцев назад"
   }
 }

--- a/lib/i18n/translations/sw.json
+++ b/lib/i18n/translations/sw.json
@@ -496,5 +496,13 @@
     "errorTitle": "Hitilafu imetokea.",
     "errorMessage": "Msimbo wa hitilafu: {errorCode}. Tafadhali jaribu tena baadaye au wasiliana na usaidizi.",
     "validationError": "Herufi, nambari, nafasi, na alama maalum zifuatazo pekee ndizo zinaruhusiwa: @ - . ! / % & , _ ( ) + : ;"
+  },
+  "presence": {
+    "seenJustNow": "Alionekana sasa hivi",
+    "seenMinutesAgo": "Alionekana dakika {count} zilizopita",
+    "seenHoursAgo": "Alionekana saa {count} zilizopita",
+    "seenDaysAgo": "Alionekana siku {count} zilizopita",
+    "seenMonthsAgo": "Alionekana miezi {count} iliyopita",
+    "seenMoreThanSixMonthsAgo": "Alionekana zaidi ya miezi 6 iliyopita"
   }
 }

--- a/lib/i18n/translations/vi.json
+++ b/lib/i18n/translations/vi.json
@@ -725,5 +725,13 @@
     "errorTitle": "Đã xảy ra lỗi.",
     "errorMessage": "Mã lỗi: {errorCode}. Vui lòng thử lại sau hoặc liên hệ bộ phận hỗ trợ.",
     "validationError": "Chỉ cho phép chữ cái, chữ số, khoảng trắng và các ký tự đặc biệt sau: @ - . ! / % & , _ ( ) + : ;"
+  },
+  "presence": {
+    "seenJustNow": "Vừa mới hoạt động",
+    "seenMinutesAgo": "Hoạt động {count} phút trước",
+    "seenHoursAgo": "Hoạt động {count} giờ trước",
+    "seenDaysAgo": "Hoạt động {count} ngày trước",
+    "seenMonthsAgo": "Hoạt động {count} tháng trước",
+    "seenMoreThanSixMonthsAgo": "Hoạt động hơn 6 tháng trước"
   }
 }

--- a/services/api/api-buy-sell.ts
+++ b/services/api/api-buy-sell.ts
@@ -11,6 +11,7 @@ export interface Advertisement {
     created_at: number
     rating_average?: number
     is_online?: boolean
+    last_online_at?: number | null
     rating_average_lifetime?: number
     order_count_lifetime?: number
     completion_average_30day?: number


### PR DESCRIPTION
## Summary
- Adds reusable last-seen presence display for offline advertisers.
- Shows last-seen text on markets advert cards, advertiser search cards, and advertiser profile.
- Keeps online state represented by existing avatar dot only, without adding new `Online` text.

## Changes
- Added `PresenceLastSeen` and `formatLastSeen` helper for shared last-seen formatting.
- Added `last_online_at` typing for advert users and advertiser profiles.
- Updated `users_online` WebSocket handlers to update `last_online_at` on offline transitions.
- Added localized `presence.*` translation keys across all supported locales.
- Replaced advertiser profile `Offline` text with `Seen ... ago | Joined on ...` when timestamp exists.

## Test Plan
- Checked touched files for lint issues.
- Verified formatter handles just now, minutes, hours, days, months, and more than 6 months.
- Verified online advertisers render no last-seen text and continue using the avatar online dot.